### PR TITLE
Fixed signed/unsigned comparison warning in `bluenrg_gap_aci.c`

### DIFF
--- a/Middlewares/ST/BlueNRG-MS/hci/controller/bluenrg_gap_aci.c
+++ b/Middlewares/ST/BlueNRG-MS/hci/controller/bluenrg_gap_aci.c
@@ -119,7 +119,7 @@ tBleStatus aci_gap_set_limited_discoverable(uint8_t AdvType, uint16_t AdvIntervM
   uint8_t buffer[40];
   uint8_t indx = 0;
     
-  if ((LocalNameLen+ServiceUUIDLen+14) > sizeof(buffer))
+  if ((LocalNameLen+ServiceUUIDLen+14u) > sizeof(buffer))
     return BLE_STATUS_INVALID_PARAMS;
 
   buffer[indx] = AdvType;
@@ -182,7 +182,7 @@ tBleStatus aci_gap_set_discoverable(uint8_t AdvType, uint16_t AdvIntervMin, uint
   uint8_t buffer[40];
   uint8_t indx = 0;
   
-  if ((LocalNameLen+ServiceUUIDLen+14) > sizeof(buffer))
+  if ((LocalNameLen+ServiceUUIDLen+14u) > sizeof(buffer))
     return BLE_STATUS_INVALID_PARAMS;
 
   buffer[indx] = AdvType;


### PR DESCRIPTION
Closes #2 
